### PR TITLE
Fix tests: Do not test different id in test_dir

### DIFF
--- a/test.py
+++ b/test.py
@@ -110,7 +110,6 @@ class TestAna(unittest.TestCase):
         ana.dl = ana.DirDataLayer(pickle_dir="/tmp/test_ana")
         two = A.ana_load(uuid)
         self.assertEquals(uuid, two.ana_uuid)
-        self.assertNotEqual(old_id, id(two))
 
         # reset the datalayer to make sure we handle it properly
         ana.set_dl(ana.DictDataLayer())


### PR DESCRIPTION
Looks like the python interpreter uses the same id if it's available, so this test fails randomly, depending on memory management.

".../ana-0.06/test.py", line 113, in test_dir
    self.assertNotEqual(old_id, id(two))
AssertionError: 140642905866320 == 140642905866320

This patch just removes the check because we cannot be sure that they are different.